### PR TITLE
Fixed level loading logic when searching entities

### DIFF
--- a/lib/register_sources_bods/register/entity.rb
+++ b/lib/register_sources_bods/register/entity.rb
@@ -7,6 +7,10 @@ require 'register_sources_bods/register/paginated_array'
 module RegisterSourcesBods
   module Register
     class Entity
+      PSC_SCHEME = 'GB-COH'.freeze
+      SK_SCHEME = 'SK-ORSR'.freeze
+      DK_SCHEME = 'DK-CVR'.freeze
+
       def initialize(bods_statement)
         @bods_statement = bods_statement
 
@@ -48,7 +52,7 @@ module RegisterSourcesBods
       end
 
       def company_number
-        bods_statement.identifiers.find { |ident| ident.scheme == "GB-COH" }&.id
+        bods_statement.identifiers.find { |ident| [PSC_SCHEME, DK_SCHEME, SK_SCHEME].include? ident.scheme }&.id
       end
 
       def company_number?

--- a/lib/register_sources_bods/register/entity_service.rb
+++ b/lib/register_sources_bods/register/entity_service.rb
@@ -22,7 +22,7 @@ module RegisterSourcesBods
         statement_ids = statements.map { |result| result.record.statementID }
         statements.map(&:record).map(&:identifiers)
 
-        result = statement_loader.load_statements(statement_ids, load_children: false)
+        result = statement_loader.load_statements(statement_ids, max_levels: 1)
 
         # new_results = identifiers.map do |identifier|
         new_results = statement_ids.map do |statement_id|
@@ -41,7 +41,7 @@ module RegisterSourcesBods
 
         statement_ids = statements.map { |result| result.record.statementID }
 
-        result = statement_loader.load_statements(statement_ids, load_children: false)
+        result = statement_loader.load_statements(statement_ids, max_levels: 1)
 
         new_results = statement_ids.map do |statement_id|
           result.entities[statement_id]&.master_entity || result.entities[statement_id] || result.relationships[statement_id]


### PR DESCRIPTION
- Allow first level of children to be loaded when performing an entity search
- Fixed issue where only GB company id was retrieved