### PR TITLE
[register#183] Register::EntityQueryBuilder: fix company number search

### DIFF
--- a/lib/register_sources_bods/register/entity_query_builder.rb
+++ b/lib/register_sources_bods/register/entity_query_builder.rb
@@ -66,9 +66,18 @@ module RegisterSourcesBods
                       },
                     },
                     {
-                      match: {
-                        company_number: {
-                          query:,
+                      nested: {
+                        path: "identifiers",
+                        query: {
+                          bool: {
+                            must: [
+                              {
+                                term: {
+                                  'identifiers.id': query,
+                                },
+                              },
+                            ],
+                          },
                         },
                       },
                     },
@@ -136,9 +145,18 @@ module RegisterSourcesBods
                       },
                     },
                     {
-                      match: {
-                        company_number: {
-                          query:,
+                      nested: {
+                        path: "identifiers",
+                        query: {
+                          bool: {
+                            must: [
+                              {
+                                term: {
+                                  'identifiers.id': query,
+                                },
+                              },
+                            ],
+                          },
                         },
                       },
                     },

--- a/spec/unit/register/entity_query_builder_spec.rb
+++ b/spec/unit/register/entity_query_builder_spec.rb
@@ -54,9 +54,18 @@ RSpec.describe RegisterSourcesBods::Register::EntityQueryBuilder do
                         },
                       },
                       {
-                        match: {
-                          company_number: {
-                            query: "Some Company",
+                        nested: {
+                          path: "identifiers",
+                          query: {
+                            bool: {
+                              must: [
+                                {
+                                  term: {
+                                    'identifiers.id': "Some Company",
+                                  },
+                                },
+                              ],
+                            },
                           },
                         },
                       },
@@ -128,9 +137,18 @@ RSpec.describe RegisterSourcesBods::Register::EntityQueryBuilder do
                         },
                       },
                       {
-                        match: {
-                          company_number: {
-                            query: "Some Company",
+                        nested: {
+                          path: "identifiers",
+                          query: {
+                            bool: {
+                              must: [
+                                {
+                                  term: {
+                                    'identifiers.id': "Some Company",
+                                  },
+                                },
+                              ],
+                            },
                           },
                         },
                       },
@@ -188,9 +206,18 @@ RSpec.describe RegisterSourcesBods::Register::EntityQueryBuilder do
                         },
                       },
                       {
-                        match: {
-                          company_number: {
-                            query: "Some Company",
+                        nested: {
+                          path: "identifiers",
+                          query: {
+                            bool: {
+                              must: [
+                                {
+                                  term: {
+                                    'identifiers.id': "Some Company",
+                                  },
+                                },
+                              ],
+                            },
                           },
                         },
                       },
@@ -260,9 +287,18 @@ RSpec.describe RegisterSourcesBods::Register::EntityQueryBuilder do
                         },
                       },
                       {
-                        match: {
-                          company_number: {
-                            query: "Some Company",
+                        nested: {
+                          path: "identifiers",
+                          query: {
+                            bool: {
+                              must: [
+                                {
+                                  term: {
+                                    'identifiers.id': "Some Company",
+                                  },
+                                },
+                              ],
+                            },
                           },
                         },
                       },


### PR DESCRIPTION
There is no longer a `company_number` field. Instead, there is nested document `identifiers`, which contains an `id` to be searched instead. To replicate the previous search behaviour, `identifiers` should be filtered by a `scheme` or `schemeName`. However, it's likely reasonable to not do so, and instead expand the scope of the search to all `identifier.id`. Doing so means that searching for LEIs also works, as well as UTRs, etc. (if they exist).

https://github.com/openownership/register/issues/183

cc @StephenAbbott 