### PR TITLE
[#171] add RecordDeserializer fix_parsed! to fix interests.share.exact

### DIFF
--- a/lib/register_sources_bods/record_deserializer.rb
+++ b/lib/register_sources_bods/record_deserializer.rb
@@ -7,9 +7,17 @@ require_relative 'structs/bods_statement'
 
 module RegisterSourcesBods
   class RecordDeserializer
+    def self.fix_parsed!(record)
+      record['interests']&.each do |interest|
+        v = interest.dig('share', 'exact')
+        v.tr!(',', '.') if v.is_a?(String) && v.include?(',')
+      end
+    end
+
     def deserialize(record)
       parsed = JSON.parse(record)
       parsed2 = RegisterCommon::Utils::Object.compact_deep(parsed, prune: true)
+      self.class.fix_parsed!(parsed2)
       BodsStatement[parsed2]
     end
   end


### PR DESCRIPTION
AM data contains `interests[].share.exact` with values like `"49,95"`. This is against BODS 0.2, which specifies that it must be a number. normally, `Float` can coerce `String`, including with a `.` decimal. When a `,` decimal is used, however, this fails.

The decision was made to fix these values in code. This is not a perfect solution, however, since there's no detection of whether `,` is in fact used as a thousands separator. Given that it's supposed to be a number anyway, according to BODS, then testing for this specific case and changing the decimal delimiter is likely acceptable.

Note, however, that this will have an effect on *all* data imported or transformed—not just AM data.

---

References https://github.com/openownership/register/issues/171 .