### PR TITLE
[#189] fix ResolverMappings OC jurisdiction to be lowercase

### DIFF
--- a/lib/register_sources_bods/mappers/resolver_mappings.rb
+++ b/lib/register_sources_bods/mappers/resolver_mappings.rb
@@ -44,7 +44,7 @@ module RegisterSourcesBods
       end
 
       def identifier_open_corporates_from_company(jurisdiction_code, company_number)
-        uri = "https://opencorporates.com/companies/#{jurisdiction_code}/#{company_number.upcase}"
+        uri = "https://opencorporates.com/companies/#{jurisdiction_code.downcase}/#{company_number.upcase}"
         RegisterSourcesBods::Identifier[{
           id: uri,
           schemeName: IDENTIFIER_NAME_OC,


### PR DESCRIPTION
In the latest attempts to properly migrate and fix #189, some OpenCorporates IDs have been added with uppercase jurisdiction codes. I'm not sure where those have come from… However, unlike company numbers, OpenCorporates doesn't appear to redirect juridiction codes to standarise them—at least via URL.

e.g.

- https://opencorporates.com/companies/gb/Sc311560 redirects to https://opencorporates.com/companies/gb/SC311560 (good!)
- https://opencorporates.com/companies/gb/SC311560 doesn't redirect (good!)
- https://opencorporates.com/companies/GB/SC311560 doesn't redirect (not good)
- https://opencorporates.com/companies/GB/Sc311560 redirects to https://opencorporates.com/companies/gb/SC311560 (um… okay…)

Attempt to standardise to specify that:

- jurisdiction code is *always* lowercase (which seems to be the majority by far)
- company number is *always* uppercase (which only affects some Scottish companies, as far as I'm aware)

---

References https://github.com/openownership/register/issues/189 .