### PR TITLE
[#222] extend Mappers::ResolverMappings, Transformer to add alt names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/openownership/register-common.git
-  revision: cda152561d801d87b4e08ae9ea24cc96d374226e
+  revision: bfa55bf6e8e758b2b27c2cb0a210d55c4edb3c7a
   specs:
     register_common (0.1.0)
       activesupport (>= 6, < 8)
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-oc.git
-  revision: 8f56cf082396d97bd1551bf63c0a0b02d542254a
+  revision: 67726f1a2f9b533369a03744090f8e0d8ffafb8c
   specs:
     register_sources_oc (0.1.0)
       activesupport (>= 6, < 8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-oc.git
-  revision: 8b7220073a415f6869abe1423ed51110d82f28ca
+  revision: 8f56cf082396d97bd1551bf63c0a0b02d542254a
   specs:
     register_sources_oc (0.1.0)
       activesupport (>= 6, < 8)

--- a/lib/register_sources_bods/mappers/resolver_mappings.rb
+++ b/lib/register_sources_bods/mappers/resolver_mappings.rb
@@ -58,6 +58,12 @@ module RegisterSourcesBods
         resolver_response.company.name
       end
 
+      def alternate_names
+        return unless resolver_response&.resolved && resolver_response&.alt_names
+
+        resolver_response.alt_names.map(&:name)
+      end
+
       def lei_identifier
         return unless resolver_response&.resolved && resolver_response&.add_ids
 

--- a/lib/register_sources_bods/migrations.rb
+++ b/lib/register_sources_bods/migrations.rb
@@ -2,3 +2,4 @@
 
 require_relative 'migrations/m_20231117_oc_case'
 require_relative 'migrations/m_20231205_resolve'
+require_relative 'migrations/m_20231213_alt_names'

--- a/lib/register_sources_bods/migrations/m_20231117_oc_case.rb
+++ b/lib/register_sources_bods/migrations/m_20231117_oc_case.rb
@@ -8,7 +8,7 @@ require_relative 'base'
 
 module RegisterSourcesBods
   module Migrations
-    class M20131117OCCase < Base
+    class M20231117OCCase < Base
       include RegisterSourcesBods::Mappers::ResolverMappings
 
       def initialize(identifiers_id_prefix = nil)

--- a/lib/register_sources_bods/migrations/m_20231205_resolve.rb
+++ b/lib/register_sources_bods/migrations/m_20231205_resolve.rb
@@ -11,7 +11,7 @@ require_relative 'base'
 
 module RegisterSourcesBods
   module Migrations
-    class M20131205Resolve < Base
+    class M20231205Resolve < Base
       include Mappers::ResolverMappings
 
       def initialize(identifiers_id_prefix = nil, index_raw = nil, index_dst = nil)

--- a/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
+++ b/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
@@ -44,7 +44,7 @@ module RegisterSourcesBods
                 else
                   @repo_bods.list_matching_at_least_one_identifier([id], latest: true)
                 end
-        stmts.each { |stmt| process_stmt(doc, id, stmt) }
+        stmts.compact.each { |stmt| process_stmt(doc, id, stmt) }
       end
 
       def process_stmt(doc, id, stmt)

--- a/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
+++ b/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
@@ -49,6 +49,7 @@ module RegisterSourcesBods
 
       def process_stmt(doc, id, stmt)
         alternate_name = doc['_source']['name']
+        stmt.alternateNames ||= []
         return if stmt.alternateNames.include?(alternate_name)
 
         stmt.alternateNames << alternate_name

--- a/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
+++ b/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
@@ -9,7 +9,7 @@ require_relative 'base'
 
 module RegisterSourcesBods
   module Migrations
-    class M20131213AltNames < Base
+    class M20231213AltNames < Base
       include RegisterSourcesBods::Mappers::ResolverMappings
 
       def initialize(jurisdiction_codes = nil, company_numbers = nil)

--- a/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
+++ b/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
@@ -49,7 +49,7 @@ module RegisterSourcesBods
 
       def process_stmt(doc, id, stmt)
         alternate_name = doc['_source']['name']
-        stmt.alternateNames ||= []
+        stmt = stmt.new(alternateNames: []) unless stmt.alternateNames
         return if stmt.alternateNames.include?(alternate_name)
 
         stmt.alternateNames << alternate_name

--- a/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
+++ b/lib/register_sources_bods/migrations/m_20231213_alt_names.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'register_sources_oc/repositories/alt_name_repository'
+
+require_relative '../mappers/resolver_mappings'
+require_relative '../repositories/bods_statement_repository'
+require_relative '../services/publisher'
+require_relative 'base'
+
+module RegisterSourcesBods
+  module Migrations
+    class M20131213AltNames < Base
+      include RegisterSourcesBods::Mappers::ResolverMappings
+
+      def initialize(jurisdiction_codes = nil, company_numbers = nil)
+        super()
+        @buffer_ids = Set.new
+        @jurisdiction_codes = jurisdiction_codes&.split(',') || []
+        @company_numbers = company_numbers&.split(',') || []
+        @repo_ocan = RegisterSourcesOc::Repositories::AltNameRepository.new
+        @repo_bods = Repositories::BodsStatementRepository.new
+        @publisher = Services::Publisher.new
+      end
+
+      private
+
+      def do_migrate
+        q = {
+          jurisdiction_codes: @jurisdiction_codes,
+          company_numbers: @company_numbers
+        }
+        @repo_ocan.each_alt_name(**q) do |doc|
+          log_doc(doc)
+          process_doc(doc)
+        end
+      end
+
+      def process_doc(doc)
+        id = identifier_open_corporates_from_company(
+          doc['_source']['jurisdiction_code'], doc['_source']['company_number']
+        )
+        stmts = if @buffer_ids.member?(id)
+                  [@buffer.find { |s| s.identifiers.include?(id) }]
+                else
+                  @repo_bods.list_matching_at_least_one_identifier([id], latest: true)
+                end
+        stmts.each { |stmt| process_stmt(doc, id, stmt) }
+      end
+
+      def process_stmt(doc, id, stmt)
+        alternate_name = doc['_source']['name']
+        return if stmt.alternateNames.include?(alternate_name)
+
+        stmt.alternateNames << alternate_name
+        return if @buffer_ids.member?(id)
+
+        append_buffer(stmt)
+        @buffer_ids.add(id)
+      end
+
+      def do_flush_buffer
+        stmts_h = @buffer.to_h { |s| [s.statementID, s] }
+        @publisher.publish_many(stmts_h)
+        @buffer_ids = Set.new
+      end
+    end
+  end
+end

--- a/lib/register_sources_bods/register/entity.rb
+++ b/lib/register_sources_bods/register/entity.rb
@@ -163,6 +163,10 @@ module RegisterSourcesBods
         end
       end
 
+      def alternate_names
+        bods_statement.alternateNames&.sort || []
+      end
+
       def natural_person?
         return false unless bods_statement
 

--- a/lib/register_sources_bods/register/entity_query_builder.rb
+++ b/lib/register_sources_bods/register/entity_query_builder.rb
@@ -49,6 +49,13 @@ module RegisterSourcesBods
                       }
                     },
                     {
+                      match_phrase: {
+                        alternateNames: {
+                          query:
+                        }
+                      }
+                    },
+                    {
                       nested: {
                         path: 'names',
                         query: {

--- a/lib/register_sources_bods/transformer/entity_statement.rb
+++ b/lib/register_sources_bods/transformer/entity_statement.rb
@@ -33,11 +33,14 @@ module RegisterSourcesBods
       end
 
       def call
-        RegisterSourcesBods::EntityStatement[bods_entity.to_h.merge({
-                                                                      identifiers:,
-                                                                      foundingDate: founding_date,
-                                                                      dissolutionDate: dissolution_date
-                                                                    }).compact]
+        RegisterSourcesBods::EntityStatement[bods_entity.to_h.merge(
+          {
+            alternateNames: alternate_names,
+            identifiers:,
+            foundingDate: founding_date,
+            dissolutionDate: dissolution_date
+          }
+        ).compact]
       end
 
       private
@@ -57,6 +60,10 @@ module RegisterSourcesBods
             name: bods_entity.name
           }.compact]
         )
+      end
+
+      def alternate_names
+        [bods_entity.alternateNames, super].flatten.compact.uniq
       end
 
       def identifiers

--- a/spec/unit/register/entity_query_builder_spec.rb
+++ b/spec/unit/register/entity_query_builder_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe RegisterSourcesBods::Register::EntityQueryBuilder do
                         }
                       },
                       {
+                        match_phrase: {
+                          alternateNames: {
+                            query: 'Some Company'
+                          }
+                        }
+                      },
+                      {
                         nested: {
                           path: 'names',
                           query: {
@@ -116,6 +123,13 @@ RSpec.describe RegisterSourcesBods::Register::EntityQueryBuilder do
                           name: {
                             query: 'Some Company',
                             slop: 50
+                          }
+                        }
+                      },
+                      {
+                        match_phrase: {
+                          alternateNames: {
+                            query: 'Some Company'
                           }
                         }
                       },


### PR DESCRIPTION
Mappers::ResolverMappings alternate_names is set to map to an array of strings. This isn't in keeping with how LEIs were done, where Identifier structs were used. However, the existing structs for alternate names don't make room for this additional information, and currently only names are needed anyway, so rather than risk numerous knock-on effects with changing the existing structs, I've opted to map to create a list of strings instead.

---

References https://github.com/openownership/register/issues/222 .