### PR TITLE
[#213] optimise combine-all to not recompress

### DIFF
--- a/bin/combine-all
+++ b/bin/combine-all
@@ -11,4 +11,4 @@ dst_f=$dst_d/all.$date$dst_ext
 mapfile -d '' src_fs < <(find "$src_d" \
     -maxdepth 1 -name "*$dst_ext" -type f -print0 | sort -z)
 mkdir -p "$dst_d"
-zcat "${src_fs[@]}" | gzip > "$dst_f"
+cat "${src_fs[@]}" > "$dst_f"


### PR DESCRIPTION
Recompressing during combination into All destination file saves only 0.3% of space, whilst taking 213x longer to run.

I'd say that's not worth it… ;)

---

References https://github.com/openownership/register/issues/213 .