### PR TITLE
[#217] change Redis connection to use URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,4 @@ BODS_S3_BUCKET_NAME=oo-register-v2
 ELASTICSEARCH_URL=http://elastic:@elasticsearch:9200
 OC_API_TOKEN=
 OC_API_TOKEN_PROTECTED=
-REDIS_HOST=redis
-REDIS_PORT=6379
+REDIS_URL=redis://redis:6379

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/openownership/register-common.git
-  revision: fc24c1ddac24515bb33429d7c8d7980d594891a0
+  revision: 7bdb2e5aa9a6c3d5744bd45bf69250aa004c784f
   specs:
     register_common (0.1.0)
       activesupport (>= 6, < 8)
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-oc.git
-  revision: 5122dae625b36ad1813f8db539dcd44bd4424c87
+  revision: 32989d175fd315a5b093f3ebcaccd7f6e5c2e031
   specs:
     register_sources_oc (0.1.0)
       activesupport (>= 6, < 8)

--- a/lib/register_sources_bods/apps/transformer_bulk.rb
+++ b/lib/register_sources_bods/apps/transformer_bulk.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'redis'
+require 'register_common/services/file_reader'
+require 'register_sources_oc/services/resolver_service'
+
+require_relative '../services/publisher'
+
+module RegisterSourcesBods
+  module Apps
+    class TransformerBulk
+      BATCH_SIZE = 25
+
+      def initialize(namespace:, parallel_files:, record_processor:, record_struct:, s3_adapter:)
+        @redis = Redis.new(url: ENV.fetch('REDIS_URL'))
+        @s3_bucket = ENV.fetch('BODS_S3_BUCKET_NAME')
+        @file_reader = RegisterCommon::Services::FileReader.new(
+          s3_adapter:, batch_size: BATCH_SIZE
+        )
+        @record_struct = record_struct
+        @s3_adapter = s3_adapter
+        entity_resolver = RegisterSourcesOc::Services::ResolverService.new
+        bods_publisher = RegisterSourcesBods::Services::Publisher.new
+        @bods_mapper = record_processor.new(entity_resolver:, bods_publisher:)
+        @namespace = namespace
+        @parallel_files = parallel_files
+      end
+
+      def transform(s3_prefix)
+        s3_paths = @s3_adapter.list_objects(s3_bucket: @s3_bucket, s3_prefix:)
+        s3_paths.each_slice(@parallel_files) do |s3_paths_batch|
+          threads = []
+          s3_paths_batch.each do |s3_path|
+            threads << Thread.new { process_s3_path(s3_path) }
+          end
+          threads.each(&:join)
+        end
+      end
+
+      private
+
+      def process_s3_path(s3_path)
+        if file_processed?(s3_path)
+          print "Skipping #{s3_path}\n"
+          return
+        end
+        print "#{Time.now} Processing #{s3_path}\n"
+        @file_reader.read_from_s3(s3_bucket: @s3_bucket, s3_path:) do |rows|
+          process_rows rows
+        end
+        mark_file_complete(s3_path)
+        print "#{Time.now} Completed #{s3_path}\n"
+      end
+
+      def process_rows(rows)
+        rows.each do |record_data|
+          record_h = JSON.parse(record_data, symbolize_names: true)
+          record = @record_struct[**record_h]
+          @bods_mapper.process(record)
+        end
+      end
+
+      def file_processed?(s3_path)
+        @redis.sismember(@namespace, s3_path)
+      end
+
+      def mark_file_complete(s3_path)
+        @redis.sadd(@namespace, [s3_path])
+      end
+    end
+  end
+end

--- a/lib/register_sources_bods/apps/transformer_stream.rb
+++ b/lib/register_sources_bods/apps/transformer_stream.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'register_common/services/stream_client_kinesis'
+require 'register_sources_oc/services/resolver_service'
+
+require_relative '../services/publisher'
+
+module RegisterSourcesBods
+  module Apps
+    class TransformerStream
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(credentials:, consumer_id:, record_processor:, record_struct:, s3_adapter:, stream_name:)
+        s3_bucket = ENV.fetch('BODS_S3_BUCKET_NAME')
+        @stream_client = RegisterCommon::Services::StreamClientKinesis.new(
+          credentials:, s3_adapter:, s3_bucket:, stream_name:
+        )
+        @consumer_id = consumer_id
+        @record_struct = record_struct
+        entity_resolver = RegisterSourcesOc::Services::ResolverService.new
+        bods_publisher = RegisterSourcesBods::Services::Publisher.new
+        @bods_mapper = record_processor.new(entity_resolver:, bods_publisher:)
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      def transform
+        @stream_client.consume(@consumer_id) do |record_data|
+          record_h = JSON.parse(record_data, symbolize_names: true)
+          record = @record_struct[**record_h]
+          @bods_mapper.process(record)
+        end
+      end
+    end
+  end
+end

--- a/lib/register_sources_bods/config/adapters.rb
+++ b/lib/register_sources_bods/config/adapters.rb
@@ -14,10 +14,7 @@ module RegisterSourcesBods
       HTTP_ADAPTER    = RegisterCommon::Adapters::HttpAdapter.new
       KINESIS_ADAPTER = RegisterCommon::Adapters::KinesisAdapter.new(credentials: AWS_CREDENTIALS)
       S3_ADAPTER      = RegisterCommon::Adapters::S3Adapter.new(credentials: AWS_CREDENTIALS)
-      REDIS_ADAPTER   = RegisterCommon::Adapters::RedisAdapter.new(
-        host: ENV.fetch('REDIS_HOST'),
-        port: ENV.fetch('REDIS_PORT')
-      )
+      REDIS_ADAPTER   = RegisterCommon::Adapters::RedisAdapter.new(url: ENV.fetch('REDIS_URL'))
       SET_CLIENT = RegisterCommon::Services::SetClientRedis.new(redis_adapter: REDIS_ADAPTER)
     end
   end


### PR DESCRIPTION
Instead of REDIS_HOST, REDIS_PORT, use a single REDIS_URL variable. This is more in keeping with how Redis services are often deployed, and mirrors the change to ELASTICSEARCH_URL.

References https://github.com/openownership/register/issues/217 .