### PR TITLE
[#251] extend TransformerStream transform to detect company number

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/openownership/register-common.git
-  revision: 8a0e737cefd63ded9d59ecdab8e1a4bd9936a693
+  revision: a1ffdbb52c56e7b92f66b726d9e0ce807ab77857
   specs:
     register_common (0.1.0)
       activesupport (>= 6, < 8)

--- a/lib/register_sources_bods/apps/transformer_stream.rb
+++ b/lib/register_sources_bods/apps/transformer_stream.rb
@@ -28,6 +28,10 @@ module RegisterSourcesBods
       def transform
         @stream_client.consume(@consumer_id) do |record_data|
           record_h = JSON.parse(record_data, symbolize_names: true)
+          unless record_h[:company_number]
+            match = %r{/company/(?<company_number>\w+)/}.match(record_h[:data][:links][:self])
+            record_h[:company_number] = match[:company_number] if match
+          end
           record = @record_struct[**record_h]
           @bods_mapper.process(record)
         end


### PR DESCRIPTION
Similar to logic in Ingester PSC streaming, attempt to detect the company number from the payload if it isn't present in the streamed data.

I'm not sure whether it's more correct to replace the company number every time, or only if it's not present. I've opted for the latter, but it's worth noting that Ingester PSC opts for the former. However, that situation might well be different.

References https://github.com/openownership/register/issues/251 .