### PR TITLE
fix TransformerBulk, TransformerStream transform for DK, SK

### DIFF
--- a/lib/register_sources_bods/apps/transformer_bulk.rb
+++ b/lib/register_sources_bods/apps/transformer_bulk.rb
@@ -62,11 +62,12 @@ module RegisterSourcesBods
       def process_rows(rows)
         rows.each do |record_data|
           record_h = JSON.parse(record_data, symbolize_names: true)
-          next if @exp_set.sismember(REDIS_TRANSFORMED_KEY, record_h[:data][:etag])
+          etag = record_h.dig(:data, :etag)
+          next if etag && @exp_set.sismember(REDIS_TRANSFORMED_KEY, etag)
 
           record = @record_struct[**record_h]
           @bods_mapper.process(record)
-          @exp_set.sadd(REDIS_TRANSFORMED_KEY, record_h[:data][:etag])
+          @exp_set.sadd(REDIS_TRANSFORMED_KEY, etag) if etag
         end
       end
 


### PR DESCRIPTION
The transformation tracking added in #254 for PSC datasource is incompatible with DK and SK, since they don't contain the same record structure.

Fix by skipping transformation tracking if these data etags are not present in the record.